### PR TITLE
bump up log4j to 2.17.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ nexusPluginVersion=1.0.0
 
 micronautVersion = 1.3.7
 sentryVersion = 1.7.30
-log4jVersion = 2.16.0
+log4jVersion = 2.17.0
 awsLog4jVersion = 1.3.0
 systemLambdaVersion = 1.2.0
 gruVersion = 0.9.4


### PR DESCRIPTION
> The Log4j team has been made aware of a security vulnerability, CVE-2021-45105, that has been addressed in Log4j 2.17.0 for Java 8 and up.
> Summary: Apache Log4j2 does not always protect from infinite recursion in lookup evaluation.