### PR TITLE
chore: upgrade log4j to 2.17.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ nexusPluginVersion=1.0.0
 
 micronautVersion = 1.3.7
 sentryVersion = 1.7.30
-log4jVersion = 2.17.0
+log4jVersion = 2.17.1
 awsLog4jVersion = 1.3.0
 systemLambdaVersion = 1.2.0
 gruVersion = 0.9.4


### PR DESCRIPTION
To fix CVE-2021-44832
Check [this](https://checkmarx.com/blog/cve-2021-44832-apache-log4j-2-17-0-arbitrary-code-execution-via-jdbcappender-datasource-element/) for mode details about the CVE