### PR TITLE
fix(ci): use :guide path for gitPublishPush, not :docs:guide

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5
       - name: Publish GitHub Pages
         run: |
-          ./gradlew :docs:guide:gitPublishPush \
+          ./gradlew :guide:gitPublishPush \
             -Pversion=${{ steps.latest_version.outputs.latest_tag }} \
             -Prelease=true \
             -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           GIT_PUBLISH_USERNAME: agorapulse-bot
           GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
-          ./gradlew :docs:guide:gitPublishPush publishAndReleaseToMavenCentral \
+          ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
             -Pversion=${{ github.ref_name }} \
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \


### PR DESCRIPTION
## Summary

The Release workflow on tag 5.0.0.RC1 failed immediately with:

```
Cannot locate tasks that match ':docs:guide:gitPublishPush' as project 'docs' not found in root project 'micronaut-log4aws-root'.
```

Build scan: https://scans.gradle.com/s/vwtz7fsspbbwa/failures

## Fix

The Agorapulse `gradleProjects` settings DSL flattens `docs/guide/` to the `:guide` project (not `:docs:guide`). `./gradlew projects` confirms it's just `:guide`. Two workflows had the wrong path:

* `.github/workflows/release.yml` — Maven Central publish + GH-Pages push during release
* `.github/workflows/publish_documentation.yml` — manual docs publish

Fixed both to use `:guide:gitPublishPush`, matching gru's already-shipping release.yml.

## After merge

The 5.0.0.RC1 tag will need to be deleted + re-cut so the Release workflow can actually publish to Maven Central.

## Test plan
- [x] `./gradlew projects` shows `:guide`, not `:docs:guide`
- [ ] CI green on this PR
- [ ] Delete + retag 5.0.0.RC1 once merged
