### PR TITLE
chore(deps): bump Micronaut to 5.0.6 and gru to 3.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,10 +27,10 @@ agorapulseGradlePluginsVersion = 4.4.2
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
 sentryVersion = 6.16.0
 log4jVersion = 2.22.0
 awsLog4jVersion = 1.6.0
 systemLambdaVersion = 1.2.1
-gruVersion = 3.0.0.RC2
+gruVersion = 3.0.0


### PR DESCRIPTION
Bumps Micronaut to 5.0.6, the Micronaut Gradle plugin to 5.0.2, and gru to the 3.0.0 GA (was 3.0.0.RC2). Part of the MN 5.0.6 OSS release train (ships as micronaut-log4aws 5.0.0 GA).