### PR TITLE
chore(deps): pin gru to 3.0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,4 +33,4 @@ sentryVersion = 6.16.0
 log4jVersion = 2.22.0
 awsLog4jVersion = 1.6.0
 systemLambdaVersion = 1.2.1
-gruVersion = 3.0.0
+gruVersion = 3.0.2


### PR DESCRIPTION
Propagates gru 3.0.2 into the dependency chain (MN 5.1.0 train). Ships as 5.0.2.